### PR TITLE
wip: IO Errors

### DIFF
--- a/LivePluginLoad/LivePluginLoad.cs
+++ b/LivePluginLoad/LivePluginLoad.cs
@@ -198,9 +198,32 @@ namespace LivePluginLoad {
 
             Assembly pluginAssembly;
 
-            var assemblyData = File.ReadAllBytes(dllFile.FullName);
-
-
+            byte[] assemblyData;
+            int failCount = 0;
+            int failCountMax = 5;
+            while (true)
+            {
+                try
+                {
+                    assemblyData = File.ReadAllBytes(dllFile.FullName);
+                    break;
+                }
+                catch (IOException)
+                {
+                    failCount++;
+                    if (failCount < failCountMax)
+                    {
+                        PluginLog.LogWarning($"Unable to read DLL at {dllFile.FullName} ({failCount}/{failCountMax})");
+                        Task.Delay(1000).Wait();
+                    }
+                    else
+                    {
+                        PluginLog.LogError($"Failed to read DLL at {dllFile.FullName}");
+                        return;
+                    }
+                }
+            }
+            
             if (File.Exists(pdbPath)) {
                 var pdbData = File.ReadAllBytes(pdbPath);
                 pluginAssembly = Assembly.Load(assemblyData, pdbData);


### PR DESCRIPTION
I've been using ILMerge to combine some dependencies, apparently the build task writes to bin at the same time that LPL is trying to read it, causing 
```
2020-11-14 11:59:30.597 -05:00 [ERR] [LivePluginLoad] UiBuilder OnBuildUi caught exception
System.IO.IOException: The process cannot access the file '...\bin\Debug\net472\Plugin.dll' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.File.InternalReadAllBytes(String path, Boolean checkHost)
   at LivePluginLoad.LivePluginLoad.LoadPlugin(String dllPath, PluginLoadConfig pluginLoadConfig)
   at LivePluginLoad.LivePluginLoad.BuildUI()
   at Dalamud.Interface.UiBuilder.OnDraw()
```

A simplistic solution, probably needs to add an exception window upon final failure, but a potentially useful idea. 